### PR TITLE
Switched to using system zip command

### DIFF
--- a/test/test__packager.py
+++ b/test/test__packager.py
@@ -99,10 +99,14 @@ class PackagerTest(unittest.TestCase):
             self.assertTrue(os.path.exists(package_file))
             
             package_contents = self.__packageContents(package_file)
-
-            self.assertEqual(4, len(package_contents))
+            
+            self.assertEqual(7, len(package_contents))
+            self.assertIn("file1", package_contents)
+            self.assertIn("directory1/", package_contents)
+            self.assertIn("directory2/", package_contents)
             self.assertIn("directory1/file1", package_contents)
             self.assertIn("directory2/file1", package_contents)
+            self.assertIn("directory2/subdir1/", package_contents)
             self.assertIn("directory2/subdir1/file1", package_contents)
 
     def test_adding_directories(self):
@@ -123,7 +127,8 @@ class PackagerTest(unittest.TestCase):
             
             package_contents = self.__packageContents(package_file)
             
-            self.assertEqual(1, len(package_contents))
+            self.assertEqual(2, len(package_contents))
+            self.assertIn("dir1/", package_contents)
             self.assertIn("dir1/file1", package_contents)
 
 

--- a/utils/packager.py
+++ b/utils/packager.py
@@ -1,7 +1,7 @@
 
 import os
 import shutil
-import zipfile
+import subprocess
 
 from tempdirectory import TempDirectory
 
@@ -89,10 +89,6 @@ class Packager:
 
 
     def __zipdir(self, path, zip_path):
-        with zipfile.ZipFile(zip_path, 'w') as zip:
-            for root, dirs, files in os.walk(path):
-                for file in files:
-                    full_path = os.path.join(root, file)
-                    sub_path = full_path[len(path):]
-                    zip.write(full_path, arcname=sub_path, compress_type=zipfile.ZIP_DEFLATED)
+        command = ["zip","-qr", zip_path, "."]
+        subprocess.check_call(command, cwd=path)
 


### PR DESCRIPTION
- There is an issue that arises when using ZipFile python module to zip the ipa (see issue #2)
- This is occurring due to the incorrect usage of the python module which produces zip files with missing directory entries (see updated tests)
- This change fixes #2 while the correct usage of ZipFile is pursued

Test Plan:

`python -m test.test__packager`