### PR TITLE
Support Relative Paths

### DIFF
--- a/test/test__packager.py
+++ b/test/test__packager.py
@@ -131,9 +131,25 @@ class PackagerTest(unittest.TestCase):
             self.assertIn("dir1/", package_contents)
             self.assertIn("dir1/file1", package_contents)
 
+    def test_relative_paths(self):
+        with TempDirectory(os.getcwd()) as tempdir:
+
+            relative_path = os.path.basename(tempdir)
+            package_file = os.path.join(relative_path,"package.zip")
+            
+            p = Packager(package_file)
+
+            self.assertFalse(os.path.exists(package_file))
+
+            p.add(self.__makeFile(tempdir,"file1"))
+            p.package()  
+
+            self.assertTrue(os.path.exists(package_file))
+            self.assertIn("file1", self.__packageContents(package_file))
+
+
 
 
 if __name__ == '__main__':
-    print __file__
     unittest.main()
 

--- a/utils/packager.py
+++ b/utils/packager.py
@@ -89,6 +89,10 @@ class Packager:
 
 
     def __zipdir(self, path, zip_path):
+        
+        if not os.path.isabs(zip_path):
+            zip_path = os.path.join(os.getcwd(), zip_path)
+
         command = ["zip","-qr", zip_path, "."]
         subprocess.check_call(command, cwd=path)
 

--- a/utils/tempdirectory.py
+++ b/utils/tempdirectory.py
@@ -18,8 +18,8 @@ class TempDirectory:
             shutil.move(file2, file1)
             shutil.move(file1, temp_file)
     """
-    def __init__(self):
-        self.path = tempfile.mkdtemp()
+    def __init__(self, location=None):
+        self.path = tempfile.mkdtemp(dir=location)
 
     def __cleanup(self):
         shutil.rmtree(self.path, ignore_errors=True)


### PR DESCRIPTION
- This diff fixes #4
- The zipped folder was getting created in the temporary directory instead of the current working directory
- Extended Temporary `TempDirectory` to take an optional `location` to allow creating temporary directories in a specific location, this was needed to enable testing relative paths
- Included test to verify the fix

Test Plan:

run `python -m test.test__packager`